### PR TITLE
Update client.go to include content-type header

### DIFF
--- a/client.go
+++ b/client.go
@@ -412,6 +412,7 @@ func (c *Client) send(verb string, p string, body io.Reader) (io.ReadCloser, int
 	}
 
 	req.Header.Add("Authorization", "Bearer "+c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := c.client.Do(req)
 	if err != nil {


### PR DESCRIPTION
the Smartsheet API requires the ("Content-Type", "application/json") for puts and posts